### PR TITLE
Enable instances

### DIFF
--- a/include/ca821x_api.h
+++ b/include/ca821x_api.h
@@ -64,6 +64,8 @@
 
 #endif
 
+struct ca821x_dev;
+
 /** Real time translations for MLME-SCAN ScanDuration (per channel) */
 enum ca821x_scan_durations {
 	SCAN_DURATION_30MS = 0,
@@ -135,31 +137,6 @@ extern int (*ca821x_wait_for_message)(
 	struct ca821x_dev *pDeviceRef
 );
 
-/******************************************************************************/
-/****** device_ref struct for all internal state                         ******/
-/******************************************************************************/
-struct ca821x_dev {
-	void *context; //For the application
-	void *exchange_context; //For the exchange
-
-	//For the API:
-	uint8_t last_wakeup_cond;
-	ca821x_api_downstream_t ca821x_api_downstream;
-
-	/** Variable for storing callback routines registered by the user */
-	struct ca821x_api_callbacks callbacks;
-
-	uint8_t extaddr[8]; /**< Mirrors nsIEEEAddress in the PIB */
-	uint16_t shortaddr; /**< Mirrors macShortAddress in the PIB */
-
-	uint8_t last_wakeup_cond;
-	uint8_t lqi_mode;
-
-	//MAC Workarounds for V1.1 and MPW silicon (V0.x)
-	uint8_t MAC_Workarounds; /**< Flag to enable workarounds for ca8210 v1.1 */
-	uint8_t MAC_MPW;         /**< Flag to enable workarounds for ca8210 v0.x */
-};
-
 extern const uint8_t sync_pairings[23];
 
 /***************************************************************************//**
@@ -212,6 +189,30 @@ struct ca821x_api_callbacks {
 		struct TDME_ERROR_indication_pset *params, struct ca821x_dev *pDeviceRef);
 	int (*generic_dispatch) (
 		const uint8_t *buf, size_t len, struct ca821x_dev *pDeviceRef);
+};
+
+/******************************************************************************/
+/****** device_ref struct for all internal state                         ******/
+/******************************************************************************/
+struct ca821x_dev {
+	void *context; //For the application
+	void *exchange_context; //For the exchange
+
+	//For the API:
+	ca821x_api_downstream_t ca821x_api_downstream;
+
+	/** Variable for storing callback routines registered by the user */
+	struct ca821x_api_callbacks callbacks;
+
+	uint8_t extaddr[8]; /**< Mirrors nsIEEEAddress in the PIB */
+	uint16_t shortaddr; /**< Mirrors macShortAddress in the PIB */
+
+	uint8_t last_wakeup_cond;
+	uint8_t lqi_mode;
+
+	//MAC Workarounds for V1.1 and MPW silicon (V0.x)
+	uint8_t MAC_Workarounds; /**< Flag to enable workarounds for ca8210 v1.1 */
+	uint8_t MAC_MPW;         /**< Flag to enable workarounds for ca8210 v0.x */
 };
 
 /******************************************************************************/

--- a/include/ca821x_api.h
+++ b/include/ca821x_api.h
@@ -100,7 +100,7 @@ enum ca821x_scan_durations {
  * \param len - The length of the command in octets
  * \param response - The buffer to populate with a received synchronous
  *                    response
- * \param pDeviceRef - Nondescript pointer to target device
+ * \param pDeviceRef - Pointer to initialised ca821x_device_ref struct
  *******************************************************************************
  * \return Effectively a bool as far as API is concerned, 0 means exchange was
  *         successful, nonzero otherwise
@@ -124,7 +124,7 @@ typedef int (*ca821x_api_downstream_t)(
  * \param cmdid - The id of the command to wait for
  * \param timeout_ms - Timeout for the wait in milliseconds
  * \param buf - The buffer to populate with the received message
- * \param pDeviceRef - Nondescript pointer to target device
+ * \param pDeviceRef - Pointer to initialised ca821x_device_ref struct
  *******************************************************************************
  * \return 0: message successfully received
  ******************************************************************************/
@@ -411,12 +411,48 @@ uint8_t TDME_SetTxPower(uint8_t txp, struct ca821x_dev *pDeviceRef);
 uint8_t TDME_GetTxPower(uint8_t *txp, struct ca821x_dev *pDeviceRef);
 
 /******************************************************************************/
-/****** API callback functions                                           ******/
+/****** API meta functions                                           ******/
 /******************************************************************************/
 
+/******************************************************************************/
+/***************************************************************************//**
+ * \brief Initialisation function for initialising a ca821x_dev data structure
+ *        for use with the API.
+ *******************************************************************************
+ * This function should be called to initialise a pDeviceRef. This should be
+ * done prior to any other use of the structure.
+ *******************************************************************************
+ * \param pDeviceRef - Pointer to ca821x_device_ref struct to be initialised.
+ *******************************************************************************
+ * \return 0: Structure successfully initialised
+ * \return -1: Structure initialisation failed (pDeviceRef cannot be NULL)
+ ******************************************************************************/
 int ca821x_api_init(struct ca821x_dev *pDeviceRef);
+
+/******************************************************************************/
+/***************************************************************************//**
+ * \brief Function for registering a callback struct for this device.
+ *******************************************************************************
+ * Depending on the exchange used, these callbacks may be called from a different
+ * processing context, and should be written accordingly.
+ *******************************************************************************
+ * \param pDeviceRef - Pointer to initialised ca821x_device_ref struct
+ ******************************************************************************/
 void ca821x_register_callbacks(struct ca821x_api_callbacks *in_callbacks,
                                struct ca821x_dev *pDeviceRef);
+
+/******************************************************************************/
+/***************************************************************************//**
+ * \brief Function called by the exchange to dispatch indications from the ca821x
+ *******************************************************************************
+ * FOR USE IN THE EXCHANGE ONLY. If the application needs to process incoming
+ * indications, this should be by connecting callbacks using
+ * ca821x_register_callbacks and a ca821x_api_callbacks struct.
+ *******************************************************************************
+ * \param buf - entire buffer of message, including command and length bytes
+ * \param len - length of buffer
+ * \param pDeviceRef - Pointer to initialised ca821x_device_ref struct
+ ******************************************************************************/
 int ca821x_downstream_dispatch(const uint8_t *buf, size_t len, struct ca821x_dev *pDeviceRef);
 
 #endif // CA821X_API_H

--- a/include/ca821x_api.h
+++ b/include/ca821x_api.h
@@ -83,8 +83,84 @@ enum ca821x_scan_durations {
 	SCAN_DURATION_252S = 14
 };
 
+/******************************************************************************/
+/****** External function pointers                                       ******/
+/******************************************************************************/
+
+/******************************************************************************/
+/***************************************************************************//**
+ * \brief Function pointer for downstream api interface.
+ *******************************************************************************
+ * This function pointer is called by all api functions when it comes to
+ * transmitting constructed commands to the transceiver. The user must implement
+ * their own downstream exchange function conforming to this prototype and
+ * assign that function to this pointer.
+ *******************************************************************************
+ * \param buf - The buffer containing the command to send downstream
+ * \param len - The length of the command in octets
+ * \param response - The buffer to populate with a received synchronous
+ *                    response
+ * \param pDeviceRef - Nondescript pointer to target device
+ *******************************************************************************
+ * \return Effectively a bool as far as API is concerned, 0 means exchange was
+ *         successful, nonzero otherwise
+ ******************************************************************************/
+typedef int (*ca821x_api_downstream_t)(
+	const uint8_t *buf,
+	size_t len,
+	uint8_t *response,
+	struct ca821x_dev *pDeviceRef
+);
+
+/******************************************************************************/
+/***************************************************************************//**
+ * \brief Function pointer for waiting for messages
+ *******************************************************************************
+ * This function pointer can be called by applications to wait for a specific
+ * primitive to be received by the interface driver underlying the api. The
+ * function should block until the primitive has been received, then copy this
+ * message into buf.
+ *******************************************************************************
+ * \param cmdid - The id of the command to wait for
+ * \param timeout_ms - Timeout for the wait in milliseconds
+ * \param buf - The buffer to populate with the received message
+ * \param pDeviceRef - Nondescript pointer to target device
+ *******************************************************************************
+ * \return 0: message successfully received
+ ******************************************************************************/
+extern int (*ca821x_wait_for_message)(
+	uint8_t cmdid,
+	int timeout_ms,
+	uint8_t *buf,
+	struct ca821x_dev *pDeviceRef
+);
+
+/******************************************************************************/
+/****** device_ref struct for all internal state                         ******/
+/******************************************************************************/
+struct ca821x_dev {
+	void *context; //For the application
+	void *exchange_context; //For the exchange
+
+	//For the API:
+	uint8_t last_wakeup_cond;
+	ca821x_api_downstream_t ca821x_api_downstream;
+
+	/** Variable for storing callback routines registered by the user */
+	struct ca821x_api_callbacks callbacks;
+
+	uint8_t extaddr[8]; /**< Mirrors nsIEEEAddress in the PIB */
+	uint16_t shortaddr; /**< Mirrors macShortAddress in the PIB */
+
+	uint8_t last_wakeup_cond;
+	uint8_t lqi_mode;
+
+	//MAC Workarounds for V1.1 and MPW silicon (V0.x)
+	uint8_t MAC_Workarounds; /**< Flag to enable workarounds for ca8210 v1.1 */
+	uint8_t MAC_MPW;         /**< Flag to enable workarounds for ca8210 v0.x */
+};
+
 extern const uint8_t sync_pairings[23];
-extern uint8_t last_wakeup_cond;
 
 /***************************************************************************//**
  * \brief API user callbacks structure
@@ -103,39 +179,39 @@ extern uint8_t last_wakeup_cond;
  ******************************************************************************/
 struct ca821x_api_callbacks {
 	int (*MCPS_DATA_indication) (
-		struct MCPS_DATA_indication_pset *params, void *pDeviceRef);
+		struct MCPS_DATA_indication_pset *params, struct ca821x_dev *pDeviceRef);
 	int (*MCPS_DATA_confirm) (
-		struct MCPS_DATA_confirm_pset *params, void *pDeviceRef);
+		struct MCPS_DATA_confirm_pset *params, struct ca821x_dev *pDeviceRef);
 	int (*MLME_ASSOCIATE_indication) (
-		struct MLME_ASSOCIATE_indication_pset *params, void *pDeviceRef);
+		struct MLME_ASSOCIATE_indication_pset *params, struct ca821x_dev *pDeviceRef);
 	int (*MLME_ASSOCIATE_confirm) (
-		struct MLME_ASSOCIATE_confirm_pset *params, void *pDeviceRef);
+		struct MLME_ASSOCIATE_confirm_pset *params, struct ca821x_dev *pDeviceRef);
 	int (*MLME_DISASSOCIATE_indication) (
-		struct MLME_DISASSOCIATE_indication_pset *params, void *pDeviceRef);
+		struct MLME_DISASSOCIATE_indication_pset *params, struct ca821x_dev *pDeviceRef);
 	int (*MLME_DISASSOCIATE_confirm) (
-		struct MLME_DISASSOCIATE_confirm_pset *params, void *pDeviceRef);
+		struct MLME_DISASSOCIATE_confirm_pset *params, struct ca821x_dev *pDeviceRef);
 	int (*MLME_BEACON_NOTIFY_indication) (
-		struct MLME_BEACON_NOTIFY_indication_pset *params, void *pDeviceRef);
+		struct MLME_BEACON_NOTIFY_indication_pset *params, struct ca821x_dev *pDeviceRef);
 	int (*MLME_ORPHAN_indication) (
-		struct MLME_ORPHAN_indication_pset *params, void *pDeviceRef);
+		struct MLME_ORPHAN_indication_pset *params, struct ca821x_dev *pDeviceRef);
 	int (*MLME_SCAN_confirm) (
-		struct MLME_SCAN_confirm_pset *params, void *pDeviceRef);
+		struct MLME_SCAN_confirm_pset *params, struct ca821x_dev *pDeviceRef);
 	int (*MLME_COMM_STATUS_indication) (
-		struct MLME_COMM_STATUS_indication_pset *params, void *pDeviceRef);
+		struct MLME_COMM_STATUS_indication_pset *params, struct ca821x_dev *pDeviceRef);
 	int (*MLME_SYNC_LOSS_indication) (
-		struct MLME_SYNC_LOSS_indication_pset *params, void *pDeviceRef);
+		struct MLME_SYNC_LOSS_indication_pset *params, struct ca821x_dev *pDeviceRef);
 	int (*HWME_WAKEUP_indication) (
-		struct HWME_WAKEUP_indication_pset *params, void *pDeviceRef);
+		struct HWME_WAKEUP_indication_pset *params, struct ca821x_dev *pDeviceRef);
 	int (*TDME_MESSAGE_indication) (
-		const char *message, size_t len, void *pDeviceRef);
+		const char *message, size_t len, struct ca821x_dev *pDeviceRef);
 	int (*TDME_RXPKT_indication) (
-		struct TDME_RXPKT_indication_pset *params, void *pDeviceRef);
+		struct TDME_RXPKT_indication_pset *params, struct ca821x_dev *pDeviceRef);
 	int (*TDME_EDDET_indication) (
-		struct TDME_EDDET_indication_pset *params, void *pDeviceRef);
+		struct TDME_EDDET_indication_pset *params, struct ca821x_dev *pDeviceRef);
 	int (*TDME_ERROR_indication) (
-		struct TDME_ERROR_indication_pset *params, void *pDeviceRef);
+		struct TDME_ERROR_indication_pset *params, struct ca821x_dev *pDeviceRef);
 	int (*generic_dispatch) (
-		const uint8_t *buf, size_t len, void *pDeviceRef);
+		const uint8_t *buf, size_t len, struct ca821x_dev *pDeviceRef);
 };
 
 /******************************************************************************/
@@ -143,39 +219,39 @@ struct ca821x_api_callbacks {
 /******************************************************************************/
 
 uint8_t MCPS_DATA_request(
-	uint8_t          SrcAddrMode,
-	uint8_t          DstAddrMode,
-	uint16_t         DstPANId,
-	union MacAddr   *pDstAddr,
-	uint8_t          MsduLength,
-	uint8_t         *pMsdu,
-	uint8_t          MsduHandle,
-	uint8_t          TxOptions,
-	struct SecSpec  *pSecurity,
-	void            *pDeviceRef
+	uint8_t            SrcAddrMode,
+	uint8_t            DstAddrMode,
+	uint16_t           DstPANId,
+	union MacAddr     *pDstAddr,
+	uint8_t            MsduLength,
+	uint8_t           *pMsdu,
+	uint8_t            MsduHandle,
+	uint8_t            TxOptions,
+	struct SecSpec    *pSecurity,
+	struct ca821x_dev *pDeviceRef
 );
 
 uint8_t MCPS_PURGE_request_sync(
-	uint8_t     *MsduHandle,
-	void        *pDeviceRef
+	uint8_t           *MsduHandle,
+	struct ca821x_dev *pDeviceRef
 );
 
 uint8_t MLME_ASSOCIATE_request(
-	uint8_t          LogicalChannel,
-	uint8_t          DstAddrMode,
-	uint16_t         DstPANId,
-	union MacAddr   *pDstAddr,
-	uint8_t          CapabilityInfo,
-	struct SecSpec  *pSecurity,
-	void            *pDeviceRef
+	uint8_t            LogicalChannel,
+	uint8_t            DstAddrMode,
+	uint16_t           DstPANId,
+	union MacAddr     *pDstAddr,
+	uint8_t            CapabilityInfo,
+	struct SecSpec    *pSecurity,
+	struct ca821x_dev *pDeviceRef
 );
 
 uint8_t MLME_ASSOCIATE_response(
-	uint8_t         *pDeviceAddress,
-	uint16_t         AssocShortAddress,
-	uint8_t          Status,
-	struct SecSpec  *pSecurity,
-	void            *pDeviceRef
+	uint8_t           *pDeviceAddress,
+	uint16_t           AssocShortAddress,
+	uint8_t            Status,
+	struct SecSpec    *pSecurity,
+	struct ca821x_dev *pDeviceRef
 );
 
 uint8_t MLME_DISASSOCIATE_request(
@@ -183,70 +259,70 @@ uint8_t MLME_DISASSOCIATE_request(
 	uint8_t            DisassociateReason,
 	uint8_t            TxIndirect,
 	struct SecSpec    *pSecurity,
-	void              *pDeviceRef
+	struct ca821x_dev *pDeviceRef
 );
 
 uint8_t MLME_GET_request_sync(
-	uint8_t      PIBAttribute,
-	uint8_t      PIBAttributeIndex,
-	uint8_t     *pPIBAttributeLength,
-	void        *pPIBAttributeValue,
-	void        *pDeviceRef
+	uint8_t            PIBAttribute,
+	uint8_t            PIBAttributeIndex,
+	uint8_t           *pPIBAttributeLength,
+	void              *pPIBAttributeValue,
+	struct ca821x_dev *pDeviceRef
 );
 
 uint8_t MLME_ORPHAN_response(
-	uint8_t          *pOrphanAddress,
-	uint16_t          ShortAddress,
-	uint8_t           AssociatedMember,
-	struct SecSpec   *pSecurity,
-	void             *pDeviceRef
+	uint8_t           *pOrphanAddress,
+	uint16_t           ShortAddress,
+	uint8_t            AssociatedMember,
+	struct SecSpec    *pSecurity,
+	struct ca821x_dev *pDeviceRef
 );
 
-uint8_t MLME_RESET_request_sync(uint8_t SetDefaultPIB, void *pDeviceRef);
+uint8_t MLME_RESET_request_sync(uint8_t SetDefaultPIB, struct ca821x_dev *pDeviceRef);
 
 uint8_t MLME_RX_ENABLE_request_sync(
-	uint8_t      DeferPermit,
-	uint32_t     RxOnTime,
-	uint32_t     RxOnDuration,
-	void        *pDeviceRef
+	uint8_t            DeferPermit,
+	uint32_t           RxOnTime,
+	uint32_t           RxOnDuration,
+	struct ca821x_dev *pDeviceRef
 );
 
 uint8_t MLME_SCAN_request(
-	uint8_t          ScanType,
-	uint32_t         ScanChannels,
-	uint8_t          ScanDuration,
-	struct SecSpec  *pSecurity,
-	void            *pDeviceRef
+	uint8_t            ScanType,
+	uint32_t           ScanChannels,
+	uint8_t            ScanDuration,
+	struct SecSpec    *pSecurity,
+	struct ca821x_dev *pDeviceRef
 );
 
 uint8_t MLME_SET_request_sync(
-	uint8_t       PIBAttribute,
-	uint8_t       PIBAttributeIndex,
-	uint8_t       PIBAttributeLength,
-	const void   *pPIBAttributeValue,
-	void         *pDeviceRef
+	uint8_t            PIBAttribute,
+	uint8_t            PIBAttributeIndex,
+	uint8_t            PIBAttributeLength,
+	const void        *pPIBAttributeValue,
+	struct ca821x_dev *pDeviceRef
 );
 
 uint8_t MLME_START_request_sync(
-	uint16_t          PANId,
-	uint8_t           LogicalChannel,
-	uint8_t           BeaconOrder,
-	uint8_t           SuperframeOrder,
-	uint8_t           PANCoordinator,
-	uint8_t           BatteryLifeExtension,
-	uint8_t           CoordRealignment,
-	struct SecSpec   *pCoordRealignSecurity,
-	struct SecSpec   *pBeaconSecurity,
-	void             *pDeviceRef
+	uint16_t           PANId,
+	uint8_t            LogicalChannel,
+	uint8_t            BeaconOrder,
+	uint8_t            SuperframeOrder,
+	uint8_t            PANCoordinator,
+	uint8_t            BatteryLifeExtension,
+	uint8_t            CoordRealignment,
+	struct SecSpec    *pCoordRealignSecurity,
+	struct SecSpec    *pBeaconSecurity,
+	struct ca821x_dev *pDeviceRef
 );
 
 uint8_t MLME_POLL_request_sync(
-	struct FullAddr   CoordAddress,
-	uint8_t           Interval[2],    /* polling interval in 0.1 seconds res */
-	                                  /* 0 means poll once */
-	                                  /* 0xFFFF means stop polling */
-	struct SecSpec   *pSecurity,
-	void             *pDeviceRef
+	struct FullAddr    CoordAddress,
+	uint8_t            Interval[2],    /* polling interval in 0.1 seconds res */
+	                                   /* 0 means poll once */
+	                                   /* 0xFFFF means stop polling */
+	struct SecSpec    *pSecurity,
+	struct ca821x_dev *pDeviceRef
 );
 
 /******************************************************************************/
@@ -254,23 +330,23 @@ uint8_t MLME_POLL_request_sync(
 /******************************************************************************/
 
 uint8_t HWME_SET_request_sync(
-	uint8_t      HWAttribute,
-	uint8_t      HWAttributeLength,
-	uint8_t     *pHWAttributeValue,
-	void        *pDeviceRef
+	uint8_t            HWAttribute,
+	uint8_t            HWAttributeLength,
+	uint8_t           *pHWAttributeValue,
+	struct ca821x_dev *pDeviceRef
 );
 
 uint8_t HWME_GET_request_sync(
-	uint8_t      HWAttribute,
-	uint8_t     *HWAttributeLength,
-	uint8_t     *pHWAttributeValue,
-	void        *pDeviceRef
+	uint8_t            HWAttribute,
+	uint8_t           *HWAttributeLength,
+	uint8_t           *pHWAttributeValue,
+	struct ca821x_dev *pDeviceRef
 );
 
 uint8_t HWME_HAES_request_sync(
-	uint8_t      HAESMode,
-	uint8_t     *pHAESData,
-	void        *pDeviceRef
+	uint8_t            HAESMode,
+	uint8_t           *pHAESData,
+	struct ca821x_dev *pDeviceRef
 );
 
 /******************************************************************************/
@@ -278,91 +354,69 @@ uint8_t HWME_HAES_request_sync(
 /******************************************************************************/
 
 uint8_t TDME_SETSFR_request_sync(
-	uint8_t      SFRPage,
-	uint8_t      SFRAddress,
-	uint8_t      SFRValue,
-	void         *pDeviceRef
+	uint8_t            SFRPage,
+	uint8_t            SFRAddress,
+	uint8_t            SFRValue,
+	struct ca821x_dev *pDeviceRef
 );
 
 uint8_t TDME_GETSFR_request_sync(
-	uint8_t      SFRPage,
-	uint8_t      SFRAddress,
-	uint8_t     *SFRValue,
-	void        *pDeviceRef
+	uint8_t            SFRPage,
+	uint8_t            SFRAddress,
+	uint8_t           *SFRValue,
+	struct ca821x_dev *pDeviceRef
 );
 
 uint8_t TDME_TESTMODE_request_sync(
-	uint8_t      TestMode,
-	void        *pDeviceRef
+	uint8_t            TestMode,
+	struct ca821x_dev *pDeviceRef
 );
 
 uint8_t TDME_SET_request_sync(
-	uint8_t      TestAttribute,
-	uint8_t      TestAttributeLength,
-	void        *pTestAttributeValue,
-	void        *pDeviceRef
+	uint8_t            TestAttribute,
+	uint8_t            TestAttributeLength,
+	void              *pTestAttributeValue,
+	struct ca821x_dev *pDeviceRef
 );
 
 uint8_t TDME_TXPKT_request_sync(
-	uint8_t      TestPacketDataType,
-	uint8_t     *TestPacketSequenceNumber,
-	uint8_t     *TestPacketLength,
-	void        *pTestPacketData,
-	void        *pDeviceRef
+	uint8_t            TestPacketDataType,
+	uint8_t           *TestPacketSequenceNumber,
+	uint8_t           *TestPacketLength,
+	void              *pTestPacketData,
+	struct ca821x_dev *pDeviceRef
 );
 
 uint8_t TDME_LOTLK_request_sync(
-	uint8_t     *TestChannel,
-	uint8_t     *TestRxTxb,
-	uint8_t     *TestLOFDACValue,
-	uint8_t     *TestLOAMPValue,
-	uint8_t     *TestLOTXCALValue,
-	void        *pDeviceRef
+	uint8_t           *TestChannel,
+	uint8_t           *TestRxTxb,
+	uint8_t           *TestLOFDACValue,
+	uint8_t           *TestLOAMPValue,
+	uint8_t           *TestLOTXCALValue,
+	struct ca821x_dev *pDeviceRef
 );
 
 /******************************************************************************/
 /****** TDME Register Default Initialisation and Checking Functions      ******/
 /******************************************************************************/
-uint8_t TDME_ChipInit(void *pDeviceRef);
-uint8_t TDME_ChannelInit(uint8_t channel, void *pDeviceRef);
+uint8_t TDME_ChipInit(struct ca821x_dev *pDeviceRef);
+uint8_t TDME_ChannelInit(uint8_t channel, struct ca821x_dev *pDeviceRef);
 uint8_t TDME_CheckPIBAttribute(
 	uint8_t      PIBAttribute,
 	uint8_t      PIBAttributeLength,
 	const void   *pPIBAttributeValue
 );
 
-uint8_t TDME_SetTxPower(uint8_t txp, void *pDeviceRef);
-uint8_t TDME_GetTxPower(uint8_t *txp, void *pDeviceRef);
+uint8_t TDME_SetTxPower(uint8_t txp, struct ca821x_dev *pDeviceRef);
+uint8_t TDME_GetTxPower(uint8_t *txp, struct ca821x_dev *pDeviceRef);
 
 /******************************************************************************/
 /****** API callback functions                                           ******/
 /******************************************************************************/
 
-void ca821x_register_callbacks(struct ca821x_api_callbacks *in_callbacks);
-int ca821x_downstream_dispatch(const uint8_t *buf, size_t len, void *pDeviceRef);
-
-/******************************************************************************/
-/****** External function pointers                                       ******/
-/******************************************************************************/
-extern int (*ca821x_api_downstream)(
-	const uint8_t *buf,
-	size_t len,
-	uint8_t *response,
-	void *pDeviceRef
-);
-
-extern int (*ca821x_wait_for_message)(
-	uint8_t cmdid,
-	int timeout_ms,
-	uint8_t *buf,
-	void *pDeviceRef
-);
-
-/******************************************************************************/
-/****** MAC Workarounds for V1.1 and MPW silicon (V0.x)                  ******/
-/******************************************************************************/
-extern uint8_t MAC_Workarounds;
-extern uint8_t MAC_MPW;
-
+int ca821x_api_init(struct ca821x_dev *pDeviceRef);
+void ca821x_register_callbacks(struct ca821x_api_callbacks *in_callbacks,
+                               struct ca821x_dev *pDeviceRef);
+int ca821x_downstream_dispatch(const uint8_t *buf, size_t len, struct ca821x_dev *pDeviceRef);
 
 #endif // CA821X_API_H

--- a/source/ca821x_api.c
+++ b/source/ca821x_api.c
@@ -1729,7 +1729,6 @@ int ca821x_downstream_dispatch(const uint8_t *buf, size_t len, struct ca821x_dev
 		break;
 	default:
 #ifdef __unix__
-		fprintf(stderr, "Unrecognised upstream command id: %d", buf[0]);
 		return -EINVAL;
 #else
 		return -ERANGE;

--- a/source/ca821x_api.c
+++ b/source/ca821x_api.c
@@ -188,7 +188,9 @@ uint8_t MCPS_DATA_request(
 		Command.Length += sizeof(struct SecSpec);
 	}
 
-	if (ca821x_api_downstream(&Command.CommandId, Command.Length + 2, NULL, pDeviceRef))
+	if (pDeviceRef->ca821x_api_downstream(&Command.CommandId,
+	                                       Command.Length + 2,
+	                                       NULL, pDeviceRef))
 		return MAC_SYSTEM_ERROR;
 
 	return MAC_SUCCESS;

--- a/source/ca821x_api.c
+++ b/source/ca821x_api.c
@@ -188,8 +188,7 @@ uint8_t MCPS_DATA_request(
 		Command.Length += sizeof(struct SecSpec);
 	}
 
-	if (pDeviceRef->ca821x_api_downstream(&Command.CommandId,
-	                                       Command.Length + 2,
+	if (pDeviceRef->ca821x_api_downstream(&Command.CommandId, Command.Length + 2,
 	                                       NULL, pDeviceRef))
 		return MAC_SYSTEM_ERROR;
 
@@ -217,7 +216,8 @@ uint8_t MCPS_PURGE_request_sync(
 	Command.Length = 1;
 	Command.PData.u8Param = *MsduHandle;
 
-	if (ca821x_api_downstream(&Command.CommandId, Command.Length + 2, &Response.CommandId, pDeviceRef))
+	if (pDeviceRef->ca821x_api_downstream(&Command.CommandId, Command.Length + 2,
+	                                      &Response.CommandId, pDeviceRef))
 		return MAC_SYSTEM_ERROR;
 
 	if (Response.CommandId != SPI_MCPS_PURGE_CONFIRM)
@@ -286,7 +286,8 @@ uint8_t MLME_ASSOCIATE_request(
 		ASSOCREQ.Security = *pSecurity;
 	}
 
-	if (ca821x_api_downstream(&Command.CommandId, Command.Length + 2, NULL, pDeviceRef))
+	if (pDeviceRef->ca821x_api_downstream(&Command.CommandId, Command.Length + 2,
+	                                       NULL, pDeviceRef))
 		return MAC_SYSTEM_ERROR;
 
 	return MAC_SUCCESS;
@@ -329,7 +330,8 @@ uint8_t MLME_ASSOCIATE_response(
 		ASSOCRSP.Security = *pSecurity;
 	}
 
-	if (ca821x_api_downstream(&Command.CommandId, Command.Length + 2, NULL, pDeviceRef))
+	if (pDeviceRef->ca821x_api_downstream(&Command.CommandId, Command.Length + 2,
+	                                       NULL, pDeviceRef))
 		return MAC_SYSTEM_ERROR;
 
 	return MAC_SUCCESS;
@@ -372,7 +374,8 @@ uint8_t MLME_DISASSOCIATE_request(
 		Command.PData.DisassocReq.Security = *pSecurity;
 	}
 
-	if(ca821x_api_downstream(&Command.CommandId, Command.Length + 2, NULL, pDeviceRef))
+	if(pDeviceRef->ca821x_api_downstream(&Command.CommandId, Command.Length + 2,
+	                                      NULL, pDeviceRef))
 		return MAC_SYSTEM_ERROR;
 
 	return MAC_SUCCESS;
@@ -411,7 +414,8 @@ uint8_t MLME_GET_request_sync(
 		GETREQ.PIBAttribute = PIBAttribute;
 		GETREQ.PIBAttributeIndex = PIBAttributeIndex;
 
-		if (ca821x_api_downstream(&Command.CommandId, Command.Length + 2, &Response.CommandId, pDeviceRef))
+		if (pDeviceRef->ca821x_api_downstream(&Command.CommandId, Command.Length + 2,
+		                                      &Response.CommandId, pDeviceRef))
 			return MAC_SYSTEM_ERROR;
 
 		if (Response.CommandId != SPI_MLME_GET_CONFIRM)
@@ -464,7 +468,8 @@ uint8_t MLME_ORPHAN_response(
 		ORPHANRSP.Security = *pSecurity;
 	}
 
-	if (ca821x_api_downstream(&Command.CommandId, Command.Length, NULL, pDeviceRef))
+	if (pDeviceRef->ca821x_api_downstream(&Command.CommandId, Command.Length,
+	                                       NULL, pDeviceRef))
 		return MAC_SYSTEM_ERROR;
 
 	return MAC_SUCCESS;
@@ -491,7 +496,8 @@ uint8_t MLME_RESET_request_sync(uint8_t SetDefaultPIB, struct ca821x_dev *pDevic
 	Command.Length = 1;
 	SIMPLEREQ.u8Param = SetDefaultPIB;
 
-	if (ca821x_api_downstream(&Command.CommandId, Command.Length + 2, &Response.CommandId, pDeviceRef))
+	if (pDeviceRef->ca821x_api_downstream(&Command.CommandId, Command.Length + 2,
+	                                      &Response.CommandId, pDeviceRef))
 		return MAC_SYSTEM_ERROR;
 
 	if (Response.CommandId != SPI_MLME_RESET_CONFIRM)
@@ -541,7 +547,8 @@ uint8_t MLME_RX_ENABLE_request_sync(
 	Command.PData.RxEnableReq.RxOnDuration[2] = LS2_BYTE(RxOnDuration);
 	Command.PData.RxEnableReq.RxOnDuration[3] = LS3_BYTE(RxOnDuration);
 
-	if (ca821x_api_downstream(&Command.CommandId, Command.Length + 2, &Response.CommandId, pDeviceRef))
+	if (pDeviceRef->ca821x_api_downstream(&Command.CommandId, Command.Length + 2,
+	                                      &Response.CommandId, pDeviceRef))
 		return MAC_SYSTEM_ERROR;
 
 	if (Response.CommandId != SPI_MLME_RX_ENABLE_CONFIRM)
@@ -588,7 +595,8 @@ uint8_t MLME_SCAN_request(
 		SCANREQ.Security = *pSecurity;
 	}
 
-	if (ca821x_api_downstream(&Command.CommandId, Command.Length + 2, NULL, pDeviceRef))
+	if (pDeviceRef->ca821x_api_downstream(&Command.CommandId, Command.Length + 2,
+	                                       NULL, pDeviceRef))
 		return MAC_SYSTEM_ERROR;
 
 	return MAC_SUCCESS;
@@ -640,7 +648,8 @@ uint8_t MLME_SET_request_sync(
 	SETREQ.PIBAttributeLength = PIBAttributeLength;
 	memcpy( SETREQ.PIBAttributeValue, pPIBAttributeValue, PIBAttributeLength );
 
-	if (ca821x_api_downstream(&Command.CommandId, Command.Length + 2, &Response.CommandId, pDeviceRef))
+	if (pDeviceRef->ca821x_api_downstream(&Command.CommandId, Command.Length + 2,
+	                                      &Response.CommandId, pDeviceRef))
 		return MAC_SYSTEM_ERROR;
 
 	if (Response.CommandId != SPI_MLME_SET_CONFIRM)
@@ -725,7 +734,8 @@ uint8_t MLME_START_request_sync(
 		*pBS = *pBeaconSecurity;
 	}
 
-	if (ca821x_api_downstream(&Command.CommandId, Command.Length + 2, &Response.CommandId, pDeviceRef))
+	if (pDeviceRef->ca821x_api_downstream(&Command.CommandId, Command.Length + 2,
+	                                      &Response.CommandId, pDeviceRef))
 		return MAC_SYSTEM_ERROR;
 
 	if (Response.CommandId != SPI_MLME_START_CONFIRM )
@@ -770,7 +780,8 @@ uint8_t MLME_POLL_request_sync(
 		POLLREQ.Security = *pSecurity;
 	}
 
-	if(ca821x_api_downstream(&Command.CommandId, Command.Length + 2, &Response.CommandId, pDeviceRef))
+	if(pDeviceRef->ca821x_api_downstream(&Command.CommandId, Command.Length + 2,
+	                                     &Response.CommandId, pDeviceRef))
 		return MAC_SYSTEM_ERROR;
 
 	if (Response.CommandId != SPI_MLME_POLL_CONFIRM)
@@ -806,7 +817,8 @@ uint8_t HWME_SET_request_sync(
 	Command.PData.HWMESetReq.HWAttributeLength = HWAttributeLength;
 	memcpy(Command.PData.HWMESetReq.HWAttributeValue, pHWAttributeValue, HWAttributeLength);
 
-	if (ca821x_api_downstream(&Command.CommandId, Command.Length + 2, &Response.CommandId, pDeviceRef))
+	if (pDeviceRef->ca821x_api_downstream(&Command.CommandId, Command.Length + 2,
+	                                      &Response.CommandId, pDeviceRef))
 		return MAC_SYSTEM_ERROR;
 
 	if (Response.CommandId != SPI_HWME_SET_CONFIRM)
@@ -842,7 +854,8 @@ uint8_t HWME_GET_request_sync(
 	Command.Length = 1;
 	Command.PData.HWMEGetReq.HWAttribute = HWAttribute;
 
-	if (ca821x_api_downstream(&Command.CommandId, Command.Length + 2, &Response.CommandId, pDeviceRef))
+	if (pDeviceRef->ca821x_api_downstream(&Command.CommandId, Command.Length + 2,
+	                                      &Response.CommandId, pDeviceRef))
 		return MAC_SYSTEM_ERROR;
 
 	if (Response.CommandId != SPI_HWME_GET_CONFIRM)
@@ -879,7 +892,8 @@ uint8_t HWME_HAES_request_sync(
 	Command.PData.HWMEHAESReq.HAESMode = HAESMode;
 	memcpy(Command.PData.HWMEHAESReq.HAESData, pHAESData, 16);
 
-	if (ca821x_api_downstream(&Command.CommandId, Command.Length + 2, &Response.CommandId, pDeviceRef))
+	if (pDeviceRef->ca821x_api_downstream(&Command.CommandId, Command.Length + 2,
+	                                      &Response.CommandId, pDeviceRef))
 		return MAC_SYSTEM_ERROR;
 
 	if (Response.CommandId != SPI_HWME_HAES_CONFIRM)
@@ -917,7 +931,8 @@ uint8_t TDME_SETSFR_request_sync(
 	Command.PData.TDMESetSFRReq.SFRAddress = SFRAddress;
 	Command.PData.TDMESetSFRReq.SFRValue   = SFRValue;
 	Response.CommandId = 0xFF;
-	if (ca821x_api_downstream(&Command.CommandId, Command.Length + 2, &Response.CommandId, pDeviceRef))
+	if (pDeviceRef->ca821x_api_downstream(&Command.CommandId, Command.Length + 2,
+	                                      &Response.CommandId, pDeviceRef))
 		return MAC_SYSTEM_ERROR;
 
 	if (Response.CommandId != SPI_TDME_SETSFR_CONFIRM)
@@ -951,7 +966,8 @@ uint8_t TDME_GETSFR_request_sync(
 	Command.PData.TDMEGetSFRReq.SFRPage = SFRPage;
 	Command.PData.TDMEGetSFRReq.SFRAddress = SFRAddress;
 
-	if (ca821x_api_downstream(&Command.CommandId, Command.Length + 2, &Response.CommandId, pDeviceRef))
+	if (pDeviceRef->ca821x_api_downstream(&Command.CommandId, Command.Length + 2,
+	                                      &Response.CommandId, pDeviceRef))
 		return MAC_SYSTEM_ERROR;
 
 	if (Response.CommandId != SPI_TDME_GETSFR_CONFIRM)
@@ -982,7 +998,8 @@ uint8_t TDME_TESTMODE_request_sync(
 	Command.Length = 1;
 	Command.PData.TDMETestModeReq.TestMode = TestMode;
 
-	if (ca821x_api_downstream(&Command.CommandId, Command.Length + 2, &Response.CommandId, pDeviceRef))
+	if (pDeviceRef->ca821x_api_downstream(&Command.CommandId, Command.Length + 2,
+	                                      &Response.CommandId, pDeviceRef))
 		return MAC_SYSTEM_ERROR;
 
 	if (Response.CommandId != SPI_TDME_TESTMODE_CONFIRM)
@@ -1024,7 +1041,8 @@ uint8_t TDME_SET_request_sync(
 	Command.PData.TDMESetReq.TDAttributeLength = TestAttributeLength;
 	memcpy(Command.PData.TDMESetReq.TDAttributeValue, pTestAttributeValue, TestAttributeLength);
 
-	if (ca821x_api_downstream(&Command.CommandId, Command.Length + 2, &Response.CommandId, pDeviceRef))
+	if (pDeviceRef->ca821x_api_downstream(&Command.CommandId, Command.Length + 2,
+	                                      &Response.CommandId, pDeviceRef))
 		return MAC_SYSTEM_ERROR;
 
 	if (Response.CommandId != SPI_TDME_SET_CONFIRM)
@@ -1069,7 +1087,8 @@ uint8_t TDME_TXPKT_request_sync(
 	if (TestPacketDataType == TDME_TXD_APPENDED)
 		memcpy(Command.PData.TDMETxPktReq.TestPacketData, pTestPacketData, *TestPacketLength);
 
-	if (ca821x_api_downstream(&Command.CommandId, Command.Length + 2, &Response.CommandId, pDeviceRef))
+	if (pDeviceRef->ca821x_api_downstream(&Command.CommandId, Command.Length + 2,
+	                                      &Response.CommandId, pDeviceRef))
 		return MAC_SYSTEM_ERROR;
 
 	if (Response.CommandId != SPI_TDME_TXPKT_CONFIRM)
@@ -1113,7 +1132,8 @@ uint8_t TDME_LOTLK_request_sync(
 	Command.PData.TDMELOTlkReq.TestChannel = *TestChannel;
 	Command.PData.TDMELOTlkReq.TestRxTxb = *TestRxTxb;
 
-	if (ca821x_api_downstream(&Command.CommandId, Command.Length + 2, &Response.CommandId, pDeviceRef))
+	if (pDeviceRef->ca821x_api_downstream(&Command.CommandId, Command.Length + 2,
+	                                      &Response.CommandId, pDeviceRef))
 		return MAC_SYSTEM_ERROR;
 
 	if (Response.CommandId != SPI_TDME_LOTLK_CONFIRM)


### PR DESCRIPTION
This pull request defines pDeviceRef to contain the API state and contexts for higher levels. The aim of this is to enable the use of multiple instances of the API in a single process.