### PR TITLE
adds test_app to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 docs/
 *.tag
 *.patch
+test/test_app


### PR DESCRIPTION
The default build command compiles a test application, which is not ignored by git and must be excluded with every change. This commit addresses this issue.